### PR TITLE
install_requires is not part of distutils, it is part of setuptools. …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 import os
 
@@ -21,9 +21,9 @@ setup(
     description='A toolbox for improving population genomes.',
     long_description=open('README.md').read(),
     install_requires=[
-        "numpy >= 1.9.0",
-        "matplotlib >= 1.4.0",
-        "biolib >= 0.0.19",
-        "jinja2 >= 2.7.3"
-        "mpld3 >= 0.2"],
+        "numpy>=1.9.0",
+        "matplotlib>=1.4.0",
+        "biolib>=0.0.19",
+        "jinja2>=2.7.3"
+        "mpld3>=0.2"],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setup(
         "matplotlib>=1.4.0",
         "biolib>=0.0.19",
         "jinja2>=2.7.3"
-        "mpld3>=0.2"],
+        "mpld3>=0.2",
+        "weightedstats"],
 )


### PR DESCRIPTION
Fix install to work at all with dependencies. install_requires is part of setuptools, not distutils. In order to require versions like this, you need to use setuptools. Also fix the spacing so it works.

Without this, the following error is returned when you try to install (including from "pip install refineM" as listed on installation instructions)

$ pip install refinem
Collecting refinem
.....
    Complete output from command python setup.py egg_info:
    error in refinem setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "'>= 0.2'"

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-D8ywWK/refinem/


So please merge this so installations can actually work.