### PR TITLE
Fix missing comma which caused mpld3 dependency to be skipped and cleanup README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,19 +5,28 @@ RefineM
 
 
 `version status <https://pypi.python.org/pypi/refinem>`_
+
 `downloads <https://pypi.python.org/pypi/refinem>`_
 
 RefineM is a set of tools for improving population genomes. It provides methods designed to improve the completeness of a genome along with methods for identifying and removing contamination. RefineM comprises only part of a full genome QC pipeline and should be used in conjunction with existing QC tools such as `CheckM <https://github.com/Ecogenomics/CheckM/wiki>`_. The functionality currently planned is:
 
 *Improve completeness:*
+
 * identify contigs with similarity to specific reference genome(s)
+
 * identify contigs with compatible GC, coverage, and tetranucleotide signatures
+
 * indetify partial population genomes which should be merged together (requires `CheckM <https://github.com/Ecogenomics/CheckM/wiki>`_)
 
+
 *Reducing contamination:*
+
 * taxonomically classify contigs within a genome in order to identify outliers
+
 * identify contigs with divergent GC content, coverage, or tetranucleotide signatures
+
 * identify contigs with a coding density suggestive of a Eukaryotic origin
+
 
 
 Install
@@ -29,8 +38,11 @@ The simplest way to install this package is through pip:
 This package requires numpy to be installed and makes use of the follow bioinformatic packages:
 
 * `prodigal <http://prodigal.ornl.gov/>`_: Hyatt D, Locascio PF, Hauser LJ, Uberbacher EC. 2012. Gene and translation initiation site prediction in metagenomic sequences. *Bioinformatics* 28: 2223-2230.
+
 * `blast+ <http://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs&DOC_TYPE=Download>`_: Camacho C, Coulouris G, Avagyan V, Ma N, Papadopoulos J, Bealer K, Madden TL. 2009. BLAST+: architecture and applications. *BMC Bioinformatics* 10:421: doi: 10.1186/1471-2105-10-421.
+
 * `diamond <http://ab.inf.uni-tuebingen.de/software/diamond/>`_ Buchfink B, Xie C, Huson DH. 2015. Fast and sensitive protein alignment using DIAMOND. *Nature Methods* 12: 59–60 doi:10.1038/nmeth.3176.
+
 * `krona <http://sourceforge.net/p/krona/home/krona/>`_ Ondov BD, Bergman NH, and Phillippy AM. 2011. Interactive metagenomic visualization in a Web browser. *BMC Bioinformatics* 12: 385.
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
             "numpy>=1.9.0",
             "matplotlib>=1.4.0",
             "biolib>=0.0.19",
-            "jinja2>=2.7.3"
+            "jinja2>=2.7.3",
             "mpld3>=0.2",
             "weightedstats"],
     )


### PR DESCRIPTION
I repeated this install from scratch, and found one more issue: There was a missing comma between ""jinja2>=2.7.3" and the following line, "mpld3>=0.2".

This caused the two strings to be concatenated, and thus it skips the "mpld3" dependency, and just tries to resolve jinja2>=2.7.3mpld3>=0.2

See pip install log:
pip install 'refinem==0.0.14'
Collecting refinem==0.0.14
.....
Requirement already satisfied (use --upgrade to upgrade): jinja2>=2.7.3mpld3>=0.2 in ./env/lib/python2.7/site-packages (from refinem==0.0.14)
....

Which leads to error:
(env) [savannah]$ ./env/bin/refinem
Traceback (most recent call last):
...........
    import mpld3
ImportError: No module named mpld3


I've checked and this error was present in:

commit db9fef999cf9b86453960b50d4e2b65384595f16
Author: dparks1134 <donovan.parks@gmail.com>
Date:   Tue May 24 11:34:33 2016 +1000

    Updated to v0.0.13

Thanks!