### PR TITLE
setup.py: Add pysam as a dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ if __name__ == '__main__':
             "biolib>=0.0.45",
             "jinja2>=2.7.3",
             "mpld3>=0.2",
-            "weightedstats"],
+            "weightedstats",
+            "pysam"],
     )


### PR DESCRIPTION
I'm not sure what the version requirement should be, but this is needed otherwise:

```
...lib/python2.7/site-packages/refinem/coverage.py", line 30, in <module>
    import pysam
ImportError: No module named pysam
```